### PR TITLE
Add stealth move rank chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 | 🛡️ | **Security**      | <ul><li>Implements secure file handling practices</li><li>Sanitizes user inputs to prevent vulnerabilities</li></ul> |
 | 📦 | **Dependencies**  | <ul><li>Relies on OpenCV, Qt, and CMake for building</li><li>Includes pre-trained model file ccn_model_default.pth</li></ul> |
 
+The main interface also shows a small bar graph below the FEN display when **Stealth Mode** is enabled, tracking how often the 1st, 2nd, and 3rd best moves were chosen.
+
 ---
 
 ## Project Structure

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include <QRandomGenerator>
 #include <QLabel>
 #include <QDebug>
+#include <QCheckBox>
 #include <QShortcut>
 #include <QScrollBar>
 #include <QStatusBar>
@@ -135,6 +136,17 @@ MainWindow::MainWindow(QWidget *parent)
         ui->pgnDisplay->clear();
     });
     connect(ui->actionOpen_Settings, &QAction::triggered, this, &MainWindow::openSettings);
+
+    auto updateStealthUI = [this](bool checked) {
+        ui->stealthDisabledLabel->setVisible(!checked);
+        ui->stealthGraphContainer->setVisible(true);
+        ui->firstMoveBar->setVisible(checked);
+        ui->secondMoveBar->setVisible(checked);
+        ui->thirdMoveBar->setVisible(checked);
+        updateStealthGraph();
+    };
+    connect(ui->stealthCheck, &QCheckBox::toggled, this, updateStealthUI);
+    updateStealthUI(ui->stealthCheck->isChecked());
 
     startStockfish();  // Launch Stockfish engine
 
@@ -506,6 +518,13 @@ void MainWindow::startStockfish() {
                         label += QString(" (Move: %1)").arg(selectedBestMoveRank);
                     }
                     ui->bestMoveDisplay->setText(label);
+                    if (selectedBestMoveRank == 1)
+                        ++bestMoveCount1;
+                    else if (selectedBestMoveRank == 2)
+                        ++bestMoveCount2;
+                    else if (selectedBestMoveRank == 3)
+                        ++bestMoveCount3;
+                    updateStealthGraph();
 
                     if (chosenMove.length() == 4) {
                         QString from = chosenMove.mid(0, 2);
@@ -961,6 +980,17 @@ void MainWindow::openSettings()
             startStockfish();
         }
     }
+}
+
+void MainWindow::updateStealthGraph() {
+    int maxCount = std::max({bestMoveCount1, bestMoveCount2, bestMoveCount3, 1});
+    ui->firstMoveBar->setMaximum(maxCount);
+    ui->secondMoveBar->setMaximum(maxCount);
+    ui->thirdMoveBar->setMaximum(maxCount);
+
+    ui->firstMoveBar->setValue(bestMoveCount1);
+    ui->secondMoveBar->setValue(bestMoveCount2);
+    ui->thirdMoveBar->setValue(bestMoveCount3);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -76,6 +76,10 @@ private:
     bool automoveInProgress = false;
     QMap<int, QPair<QString, int>> multipvMoves;
     int selectedBestMoveRank = 1;
+    int bestMoveCount1 = 0;
+    int bestMoveCount2 = 0;
+    int bestMoveCount3 = 0;
+    void updateStealthGraph();
     double accuracy = 0.9;
     QElapsedTimer screenshotElapsed;
     QElapsedTimer fenElapsed;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -339,12 +339,80 @@ border: 1px solid #444;
         </widget>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="fenDisplay">
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
+       <widget class="QPlainTextEdit" name="fenDisplay">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="stealthGraphContainer" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_graph">
+         <item>
+          <widget class="QLabel" name="stealthDisabledLabel">
+           <property name="text">
+            <string>Stealth Mode Disabled</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_graph">
+           <item>
+            <widget class="QProgressBar" name="firstMoveBar">
+             <property name="value">
+              <number>0</number>
+             </property>
+             <property name="textVisible">
+              <bool>true</bool>
+             </property>
+             <property name="format">
+              <string>1st: %v</string>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QProgressBar" name="secondMoveBar">
+             <property name="value">
+              <number>0</number>
+             </property>
+             <property name="textVisible">
+              <bool>true</bool>
+             </property>
+             <property name="format">
+              <string>2nd: %v</string>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QProgressBar" name="thirdMoveBar">
+             <property name="value">
+              <number>0</number>
+             </property>
+             <property name="textVisible">
+              <bool>true</bool>
+             </property>
+             <property name="format">
+              <string>3rd: %v</string>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION
## Summary
- show bar graph of best-move ranks when Stealth Mode is active
- hide graph and show message when Stealth Mode is disabled
- track counts in `MainWindow`
- document the new graph in README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_68462dbd34ac8326909a50c0c69be4d4