### PR TITLE
Add stealth move bar chart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Charts)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Charts)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Svg)
 
 set(PROJECT_SOURCES
@@ -55,7 +55,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg)
+target_link_libraries(ChessGUI PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Svg Qt${QT_VERSION_MAJOR}::Charts)
 
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 | 🛡️ | **Security**      | <ul><li>Implements secure file handling practices</li><li>Sanitizes user inputs to prevent vulnerabilities</li></ul> |
 | 📦 | **Dependencies**  | <ul><li>Relies on OpenCV, Qt, and CMake for building</li><li>Includes pre-trained model file ccn_model_default.pth</li></ul> |
 
+When **Stealth Mode** is active, a small bar chart appears below the FEN display showing how many times you selected the 1st, 2nd, or 3rd ranked move. When the mode is off, the chart is hidden and the area reads "Stealth Mode Disabled".
+
 ---
 
 ## Project Structure

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -13,6 +13,11 @@
 #include <QMap>
 #include <QPair>
 #include <QElapsedTimer>
+#include <QtCharts/QChartView>
+#include <QtCharts/QBarSet>
+#include <QtCharts/QBarSeries>
+#include <QtCharts/QBarCategoryAxis>
+#include <QtCharts/QValueAxis>
 #include "globalhotkeymanager.h"
 
 
@@ -76,6 +81,16 @@ private:
     bool automoveInProgress = false;
     QMap<int, QPair<QString, int>> multipvMoves;
     int selectedBestMoveRank = 1;
+    int bestMoveCount1 = 0;
+    int bestMoveCount2 = 0;
+    int bestMoveCount3 = 0;
+    QtCharts::QChartView* stealthChartView = nullptr;
+    QtCharts::QChart* stealthChart = nullptr;
+    QtCharts::QBarSet* set1 = nullptr;
+    QtCharts::QBarSet* set2 = nullptr;
+    QtCharts::QBarSet* set3 = nullptr;
+    QtCharts::QValueAxis* stealthAxisY = nullptr;
+    void updateStealthGraph();
     double accuracy = 0.9;
     QElapsedTimer screenshotElapsed;
     QElapsedTimer fenElapsed;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -339,12 +339,31 @@ border: 1px solid #444;
         </widget>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="fenDisplay">
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
+       <widget class="QPlainTextEdit" name="fenDisplay">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="stealthGraphContainer" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_graph">
+         <item>
+          <widget class="QLabel" name="stealthDisabledLabel">
+           <property name="text">
+            <string>Stealth Mode Disabled</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QChartView" name="stealthChartView"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION
## Summary
- track selections of first-, second-, and third-best moves
- show a QtCharts bar chart under the FEN display when Stealth Mode is on
- hide the chart and display a label when Stealth Mode is off
- document chart feature in README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake qt6-config.cmake Qt5Config.cmake qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68462dbd34ac8326909a50c0c69be4d4