### PR TITLE
Fix Windows build issue with min/max macros

### DIFF
--- a/globalhotkeymanager.h
+++ b/globalhotkeymanager.h
@@ -6,7 +6,16 @@
 #ifdef Q_OS_WIN
 #include <QAbstractNativeEventFilter>
 #include <QMap>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
 #endif
 
 class GlobalHotkeyManager : public QObject


### PR DESCRIPTION
## Summary
- fix `windows.h` min/max macro conflict by defining NOMINMAX and undefining the macros

## Testing
- `cmake ..` *(fails: Could not find OpenCVConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68463120f7b883269be9039fdc8dad38