### PR TITLE
Fix QtCharts namespace usage

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -20,6 +20,7 @@
 #include <QtCharts/QValueAxis>
 #include "globalhotkeymanager.h"
 
+QT_CHARTS_USE_NAMESPACE
 
 QT_BEGIN_NAMESPACE
 namespace Ui {


### PR DESCRIPTION
## Summary
- update header to use the QtCharts namespace correctly

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_68463339748083269ed898e4c9886599