### PR TITLE
Fix analysis toggle

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -641,7 +641,24 @@ void MainWindow::on_toggleAnalysisButton_clicked() {
     QString command = QString("\"%1\" \"%2\" \"%3\" > \"%4\" 2>&1")
                           .arg(pythonExe, pythonScript, modelPath, logPath);
 
-    analysisRunning = !analysisRunning;
+    if (analysisRunning) {
+        screenshotTimer->stop();
+        if (fenServer && fenServer->state() != QProcess::NotRunning) {
+            fenServer->kill();
+            fenServer->waitForFinished(3000);
+        }
+        ui->toggleAnalysisButton->setText("Start Analysis (Ctrl +A)");
+        updateStatusLabel("Idle");
+        setStatusLight("gray");
+        analysisRunning = false;
+    } else {
+        startFenServer();
+        screenshotTimer->start(analysisInterval);
+        ui->toggleAnalysisButton->setText("Stop Analysis (Ctrl +A)");
+        updateStatusLabel("Analyzing...");
+        setStatusLight("yellow");
+        analysisRunning = true;
+    }
 
 }
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -239,6 +239,9 @@ border: 1px solid #444;
          </item>
          <item>
           <widget class="QPushButton" name="toggleAnalysisButton">
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
            <property name="text">
             <string>Start Analysis (Ctrl +A)</string>
            </property>


### PR DESCRIPTION
## Summary
- ensure start analysis button toggles analysis logic
- allow `toggleAnalysisButton` to be checkable

## Testing
- `cmake ..` *(fails: Could not find QT)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7dfb2688326a03f1b88ba93f8ff