### PR TITLE
Fix analysis toggle

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -629,20 +629,41 @@ void MainWindow::on_toggleAnalysisButton_clicked() {
     QString pythonScript = QCoreApplication::applicationDirPath() + "/python/fen_tracker/main.py";
     QSettings settings("ChessGUI", "ChessGUI");
     QString modelPath = settings.value("fenModelPath").toString();
-    QString logPath = QCoreApplication::applicationDirPath() + "/analysis_log.txt";
 
-    // Log values to help debug
-    qDebug() << "[Python] Exe:" << pythonExe;
-    qDebug() << "[Python] Exists?" << QFile::exists(pythonExe);
-    qDebug() << "[Python] Script:" << pythonScript;
-    qDebug() << "[Python] Model:" << modelPath;
+    if (analysisRunning) {
+        screenshotTimer->stop();
+        if (fenServer && fenServer->state() != QProcess::NotRunning) {
+            fenServer->kill();
+            fenServer->waitForFinished(3000);
+        }
+        ui->toggleAnalysisButton->setText("Start Analysis (Ctrl +A)");
+        updateStatusLabel("Idle");
+        setStatusLight("gray");
+        analysisRunning = false;
+        return;
+    }
 
-    // Build the command
-    QString command = QString("\"%1\" \"%2\" \"%3\" > \"%4\" 2>&1")
-                          .arg(pythonExe, pythonScript, modelPath, logPath);
+    if (captureRegion.isNull()) {
+        on_setRegionButton_clicked();
+        if (captureRegion.isNull()) {
+            QMessageBox::warning(this, tr("No Region"), tr("Please select a board region first."));
+            ui->toggleAnalysisButton->setChecked(false);
+            return;
+        }
+    }
 
-    analysisRunning = !analysisRunning;
+    if (!QFile::exists(pythonExe) || !QFile::exists(pythonScript) || !QFile::exists(modelPath)) {
+        QMessageBox::warning(this, tr("Missing Files"), tr("Python executable or model not found."));
+        ui->toggleAnalysisButton->setChecked(false);
+        return;
+    }
 
+    startFenServer();
+    screenshotTimer->start(analysisInterval);
+    ui->toggleAnalysisButton->setText("Stop Analysis (Ctrl +A)");
+    updateStatusLabel("Analyzing...");
+    setStatusLight("yellow");
+    analysisRunning = true;
 }
 
 void MainWindow::runFenPrediction(const QString& imagePath) {

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -239,6 +239,9 @@ border: 1px solid #444;
          </item>
          <item>
           <widget class="QPushButton" name="toggleAnalysisButton">
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
            <property name="text">
             <string>Start Analysis (Ctrl +A)</string>
            </property>


### PR DESCRIPTION
## Summary
- ensure start analysis button toggles analysis logic
- allow `toggleAnalysisButton` to be checkable
- prompt for board region if analysis starts with none

## Testing
- `cmake ..` *(fails: Could not find QT)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7dfb2688326a03f1b88ba93f8ff