### PR TITLE
Fix duplicate check and ensure process cleanup

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -189,16 +189,6 @@ MainWindow::MainWindow(QWidget *parent)
 
 
 
-            if (output == "ready") {
-                qDebug() << "[fen_server] Ready";
-                return;
-            }
-
-            if (output.startsWith("[error]")) {
-                qDebug() << "[fen_server] Error:" << output;
-                return;
-            }
-
             if (output.startsWith("[FEN] ")) {
                 QString fen = output.mid(6);  // Skip "[FEN] "
                 QString pieceLayout = fen.section(" ", 0, 0);
@@ -256,6 +246,16 @@ MainWindow::~MainWindow()
 {
     QString tempDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
     QFile::remove(QDir(tempDir).filePath("chessgui_last_screenshot.png"));
+    if (screenshotTimer)
+        screenshotTimer->stop();
+    if (fenServer && fenServer->state() != QProcess::NotRunning) {
+        fenServer->kill();
+        fenServer->waitForFinished(3000);
+    }
+    if (stockfishProcess && stockfishProcess->state() != QProcess::NotRunning) {
+        stockfishProcess->kill();
+        stockfishProcess->waitForFinished(3000);
+    }
     delete ui;
 }
 


### PR DESCRIPTION
## Summary
- remove duplicated readiness and error checks when reading FEN server output
- stop timers and terminate processes in `MainWindow` destructor for clean exit

## Testing
- `cmake ..` *(fails: Could not find Qt)*

------
https://chatgpt.com/codex/tasks/task_e_6847f523db908326904b996a7c31a78d