### PR TITLE
Improve best move logic with stealth integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 - **🎯 Detect chessboard patterns:** Ensure accuracy in image analysis.
 - **⌨️ Global hotkeys:** Streamline user interaction.
 - **🧠 Process real-time images:** Utilize neural networks for advanced gameplay tracking.
+- **🤫 Stealth mode with best-move randomization:** Uses multiple engine lines to disguise suggestions.
 
 ---
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -66,6 +66,13 @@ private:
     void startFenServer();
     QLabel* evalScoreLabel = nullptr;
     void updateEvalLabel();
+
+    struct MoveChoice {
+        QString move;
+        int rank = 1;
+        int score = 0;
+    };
+    MoveChoice pickBestMove(bool stealth);
     SettingsDialog* settingsDialog = nullptr;
     QString currentBestMove;
     void playBestMove();


### PR DESCRIPTION
## Summary
- centralize picking of best move into `pickBestMove`
- use MultiPV results to randomize move when stealth mode is enabled
- document stealth best move randomization in README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*
- `cmake --build build -j2` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6847fd0534f48326a88fd184435b2e69