### PR TITLE
Prevent repeated reversal moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 - **⌨️ Global hotkeys:** Streamline user interaction.
 - **🧠 Process real-time images:** Utilize neural networks for advanced gameplay tracking.
 - **🤫 Stealth mode with best-move randomization:** Uses multiple engine lines to disguise suggestions, but stops randomizing once the evaluation is clearly winning (about +3 pawns).
+- **♻️ Repetition avoidance:** Detects potential threefold repetition and excludes the immediate reversal move when necessary.
 
 ---
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -80,6 +80,8 @@ private:
     QString lastEvaluatedFen;
     QQueue<QString> recentBestMoves;
     QString lastPlayedFen;
+    QString lastOwnMove;
+    QHash<QString, int> repetitionTable;
     bool automoveInProgress = false;
     QMap<int, QPair<QString, int>> multipvMoves;
     int selectedBestMoveRank = 1;


### PR DESCRIPTION
## Summary
- keep track of last executed move and position counts
- query Stockfish again if its best move simply undoes our previous turn
- update README with repetition avoidance feature

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684805c272cc8326964328f7d6e98b82