### PR TITLE
Improve repetition avoidance

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -76,6 +76,8 @@ private:
     SettingsDialog* settingsDialog = nullptr;
     QString currentBestMove;
     void playBestMove();
+    void playMove(const QString &uci);
+    void updateRepetitionTable(const QString &fen, bool afterMove = true);
     bool isMyTurn = false;
     QString lastEvaluatedFen;
     QQueue<QString> recentBestMoves;


### PR DESCRIPTION
## Summary
- use current board FEN when checking repetition
- make take-back veto asynchronous
- add helpers `playMove` and `updateRepetitionTable`
- simplify `pickBestMove`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68480a8da1748326b8f691634fd7dd99