### PR TITLE
Improve analysis stability and stealth

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 - **🎯 Detect chessboard patterns:** Ensure accuracy in image analysis.
 - **⌨️ Global hotkeys:** Streamline user interaction.
 - **🧠 Process real-time images:** Utilize neural networks for advanced gameplay tracking.
-- **🤫 Stealth mode with best-move randomization:** Uses multiple engine lines to disguise suggestions, but stops randomizing once the evaluation is clearly winning (about +3 pawns).
+- **🤫 Stealth mode with best-move randomization:** Stockfish now evaluates the top three moves and randomly picks among those within 30 centipawns of the best move, stopping randomization once the evaluation is clearly winning (about +3 pawns).
 - **♻️ Repetition avoidance:** Detects potential threefold repetition and excludes the immediate reversal move when necessary.
 
 ---

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -103,6 +103,7 @@ private:
     int pendingEvalLine = -1;
 
     bool restartStockfishOnCrash = true;
+    bool restartFenServerOnCrash = true;
 
     QString pythonExe;
     QString pythonScript;


### PR DESCRIPTION
## Summary
- keep FEN server process alive while analysis runs and restart if it crashes
- avoid restarting FEN server when stopping analysis or quitting
- randomise move choice in stealth mode between close alternatives
- document improved stealth move selection

## Testing
- `cmake ..` *(fails: Could not find Qt package)*

------
https://chatgpt.com/codex/tasks/task_e_684942fb72688326a9701b06883c8857