### PR TITLE
Keep fenServer alive across analysis toggles

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -96,6 +96,7 @@ MainWindow::MainWindow(QWidget *parent)
 #endif
 
     fenServer = new QProcess(this);
+    startFenServer();
     board = new BoardWidget();
     QVBoxLayout* layout = new QVBoxLayout(ui->chessBoardFrame);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -675,18 +676,8 @@ void MainWindow::startFenServer() {
 
 
 void MainWindow::on_toggleAnalysisButton_clicked() {
-    QString pythonExe = QCoreApplication::applicationDirPath() + "/python/python.exe";
-    QString pythonScript = QCoreApplication::applicationDirPath() + "/python/fen_tracker/main.py";
-    QSettings settings("ChessGUI", "ChessGUI");
-    QString modelPath = settings.value("fenModelPath").toString();
-
     if (analysisRunning) {
         screenshotTimer->stop();
-        if (fenServer && fenServer->state() != QProcess::NotRunning) {
-            restartFenServerOnCrash = false;
-            fenServer->kill();
-            fenServer->waitForFinished(3000);
-        }
         ui->toggleAnalysisButton->setText("Start Analysis (Ctrl +A)");
         updateStatusLabel("Idle");
         setStatusLight("gray");
@@ -703,13 +694,6 @@ void MainWindow::on_toggleAnalysisButton_clicked() {
         }
     }
 
-    if (!QFile::exists(pythonExe) || !QFile::exists(pythonScript) || !QFile::exists(modelPath)) {
-        QMessageBox::warning(this, tr("Missing Files"), tr("Python executable or model not found."));
-        ui->toggleAnalysisButton->setChecked(false);
-        return;
-    }
-
-    startFenServer();
     screenshotTimer->start(analysisInterval);
     ui->toggleAnalysisButton->setText("Stop Analysis (Ctrl +A)");
     updateStatusLabel("Analyzing...");

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -105,9 +105,6 @@ private:
     bool restartStockfishOnCrash = true;
     bool restartFenServerOnCrash = true;
 
-    QString pythonExe;
-    QString pythonScript;
-    QString modelPath;
 
 
 protected:


### PR DESCRIPTION
## Summary
- warm-load fenServer in MainWindow constructor
- simplify analysis toggle to keep the Python process running
- clean up unused member variables

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6849469dc0948326b2e3771b8f4cd27b