### PR TITLE
Fix python folder install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,10 @@ add_custom_command(
 )
 
 # Install into package
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/external/python"
-        DESTINATION python PATTERN "__pycache__" EXCLUDE)
+# Install Python scripts without preserving the top-level directory
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/external/python/"
+        DESTINATION python
+        PATTERN "__pycache__" EXCLUDE)
 
 
 install(FILES ${CPACK_INSTALL_SYSTEM_RUNTIME_LIBS}


### PR DESCRIPTION
## Summary
- fix install command so python scripts don't install into a nested `python/python` directory

## Testing
- `cmake -S . -B build` *(fails: Could not find QT)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa316cf48326bf6fdc221ab036cd