### PR TITLE
Rewrite eval bar animation

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -13,6 +13,7 @@
 #include <QMap>
 #include <QPair>
 #include <QElapsedTimer>
+#include <QVariantAnimation>
 #include "globalhotkeymanager.h"
 
 
@@ -65,6 +66,9 @@ private:
     void updateStatusLabel(const QString& text);
     void startFenServer();
     QLabel* evalScoreLabel = nullptr;
+    QVariantAnimation* evalAnimation = nullptr;
+    void setEvalBarValue(int value);
+    int scaleEval(int cp) const;
     void updateEvalLabel();
 
     struct MoveChoice {


### PR DESCRIPTION
## Summary
- smoothly animate evaluation bar changes
- transform centipawn scores via `tanh` for a more nuanced display

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684a030372a4832683f35ea86f0835fa