### PR TITLE
Add reset game button

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This project uses a custom CNN (Convolutional Neural Network) to visually scan i
 - **🧠 Process real-time images:** Utilize neural networks for advanced gameplay tracking.
 - **🤫 Stealth mode with best-move randomization:** Stockfish now evaluates the top three moves and randomly picks among those within 30 centipawns of the best move, stopping randomization once the evaluation is clearly winning (about +3 pawns).
 - **♻️ Repetition avoidance:** Detects potential threefold repetition and excludes the immediate reversal move when necessary.
+- **🔄 Reset Game button:** Quickly clear the board and history to start a new game.
 
 ---
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -992,6 +992,44 @@ void MainWindow::openSettings()
     }
 }
 
+void MainWindow::on_resetGameButton_clicked()
+{
+    if (analysisRunning) {
+        screenshotTimer->stop();
+        analysisRunning = false;
+        ui->toggleAnalysisButton->setChecked(false);
+        ui->toggleAnalysisButton->setText("Start Analysis (Ctrl +A)");
+    }
+
+    lastFen.clear();
+    lastEvaluatedFen.clear();
+    lastPlayedFen.clear();
+    lastOwnMove.clear();
+    boardTurnColor.clear();
+    repetitionTable.clear();
+    multipvMoves.clear();
+    currentBestMove.clear();
+    pendingEvalLine = -1;
+    lastEvalForMe = 0.0;
+    lastEvalValid = false;
+    moveHistoryLines.clear();
+
+    if (board) {
+        board->setPositionFromFen("", getMyColor() == "b");
+        board->setArrows({});
+    }
+
+    ui->pgnDisplay->clear();
+    ui->fenDisplay->setPlainText("Waiting for FEN...");
+    ui->bestMoveDisplay->clear();
+    evalScoreLabel->clear();
+    setEvalBarValue(0);
+
+    updateStatusLabel("Idle");
+    setStatusLight("gray");
+    statusBar()->showMessage("Game reset");
+}
+
 MainWindow::MoveChoice MainWindow::pickBestMove(bool stealth)
 {
     MoveChoice choice;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -34,6 +34,7 @@ public:
 private slots:
     void on_setRegionButton_clicked();
     void on_toggleAnalysisButton_clicked();
+    void on_resetGameButton_clicked();
     void openSettings();
 
 private:

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -228,27 +228,34 @@ border: 1px solid #444;
     <item>
      <widget class="QWidget" name="rightPanel" native="true">
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
-          <widget class="QPushButton" name="setRegionButton">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QPushButton" name="setRegionButton">
+             <property name="text">
+              <string>Set Region</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="toggleAnalysisButton">
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Start Analysis (Ctrl +A)</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QPushButton" name="resetGameButton">
            <property name="text">
-            <string>Set Region</string>
+            <string>Reset Game</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QPushButton" name="toggleAnalysisButton">
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Start Analysis (Ctrl +A)</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item>
         <widget class="QGroupBox" name="selectSide">
          <property name="title">


### PR DESCRIPTION
## Summary
- add Reset Game button to main window UI
- implement `on_resetGameButton_clicked` to clear game state
- expose reset slot in header
- document new feature in README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684a3ea31a948326be89d81e3fcad8db